### PR TITLE
Allow specifying an explicit schema module

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 23.3.4.4
+elixir 1.12.2-otp-23

--- a/lib/ex_json_schema/schema.ex
+++ b/lib/ex_json_schema/schema.ex
@@ -4,7 +4,7 @@ defmodule ExJsonSchema.Schema do
   end
 
   defmodule InvalidSchemaError do
-    defexception message: "invalid schema"
+    defexception message: "invalid schema", errors: []
   end
 
   defmodule MissingJsonDecoderError do
@@ -75,7 +75,8 @@ defmodule ExJsonSchema.Schema do
 
       {:error, errors} ->
         raise InvalidSchemaError,
-          message: "schema did not pass validation against its meta-schema: #{inspect(errors)}"
+          message: "schema did not pass validation against its meta-schema: #{inspect(errors)}",
+          errors: errors
     end
 
     {root, schema} = resolve_with_root(root, schema)

--- a/lib/ex_json_schema/schema.ex
+++ b/lib/ex_json_schema/schema.ex
@@ -67,6 +67,22 @@ defmodule ExJsonSchema.Schema do
     resolve(%Root{schema: schema}, options)
   end
 
+  def resolve_with_schema(schema, schema_module) when is_map(schema) and is_atom(schema_module) do
+    root = %Root{schema: schema}
+    case assert_valid_schema(schema, schema_module) do
+      :ok ->
+        :ok
+
+      {:error, errors} ->
+        raise InvalidSchemaError,
+          message: "schema did not pass validation against its meta-schema: #{inspect(errors)}"
+    end
+
+    {root, schema} = resolve_with_root(root, schema)
+
+    %Root{root | schema: schema, version: "#{inspect(schema_module)}"}
+  end
+
   @spec get_fragment(Root.t(), ref_path | ExJsonSchema.json_path()) ::
           {:ok, resolved} | invalid_reference_error | no_return
   def get_fragment(root = %Root{}, path) when is_binary(path) do
@@ -149,14 +165,18 @@ defmodule ExJsonSchema.Schema do
   defp schema_module(_, default), do: default
 
   @spec assert_valid_schema(map) :: :ok | {:error, Validator.errors()}
-  defp assert_valid_schema(schema) do
+  defp assert_valid_schema(schema, override_module \\ nil) do
     with false <- meta04?(schema),
          false <- meta06?(schema),
          false <- meta07?(schema) do
       schema_module =
+      if override_module do
+        override_module
+      else
         schema
         |> Map.get("$schema", @current_draft_schema_url <> "#")
         |> schema_module()
+      end
 
       schema_module.schema()
       |> resolve()

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule ExJsonSchema.Mixfile do
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:excoveralls, "~> 0.10", only: :test},
       {:httpoison, "~> 0.8", only: :test},
-      {:mix_test_watch, "~> 0.2.6", only: [:dev, :test]},
+      {:mix_test_watch, "~> 1.0.0", only: [:dev, :test]},
       {:poison, "~> 1.5", only: :test}
     ]
   end


### PR DESCRIPTION
Adds a new function `resolve_with_schema/2` to the `Schema` module that allows us to explicitly provide a schema module. This will let use pass in schemas that match specific OpenAPI versions.